### PR TITLE
Potential fix for code scanning alert no. 96: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Python Lint Workflow
+permissions:
+  contents: read
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,4 @@
 name: Python Lint Workflow
-permissions:
-  contents: read
 on:
   push:
     branches: ["main"]
@@ -10,6 +8,10 @@ on:
   schedule:
     - cron: "22 3 * * 2"
   workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/conan-dependency-submission/security/code-scanning/96](https://github.com/advanced-security/conan-dependency-submission/security/code-scanning/96)

To address the issue, we should add a `permissions` block to the workflow, either at the root level (making it apply to all jobs unless overridden), or to the specific job if that is preferable. The minimal required permission for a lint workflow is usually `contents: read`, unless the workflow later adds comments to PRs or pushes changes (none of which is visible in your snippet). The best place is immediately under the workflow name at the top of the file. No imports or other changes are necessary; simply add

```yaml
permissions:
  contents: read
```

as the default minimal permissions block. If later jobs require more, adjust them separately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
